### PR TITLE
refs: #15 - Multiple authors support added. Based on main configuration file.

### DIFF
--- a/src/config.toml
+++ b/src/config.toml
@@ -7,6 +7,7 @@ title = "Tech @ SparkFabrik"
   description = "Sparkfabrik tech blog"
 
   [Params.Authors]
+
     [Params.Authors.Stick]
       name = "Paolo Pustorino"
       role = "CEO"
@@ -31,6 +32,13 @@ title = "Tech @ SparkFabrik"
       github = "http://www.github.com/pinolo"
       twitter = "http://www.twitter.com/pinolo"
 
+    [Params.Authors.Marcello]
+      name = "Marcello Gorla"
+      role = "Frontend Developer"
+      picture = "http://www.sparkfabrik.com/images/team/mg.png"
+      bio = "Designer, developer and games addicted. Sometimes all three of them apply."
+      github = "http://www.github.com/mgdesign"
+      twitter = "http://www.twitter.com/mgdesign"
 
 [Author]
   name = "Sparkfabrik"

--- a/src/config.toml
+++ b/src/config.toml
@@ -6,6 +6,32 @@ title = "Tech @ SparkFabrik"
   logo = "img/sfgear.png"
   description = "Sparkfabrik tech blog"
 
+  [Params.Authors]
+    [Params.Authors.Stick]
+      name = "Paolo Pustorino"
+      role = "CEO"
+      picture = "http://www.sparkfabrik.com/images/team/pusto.png"
+      bio = "Drummer, tabletop role-player and developer. Incidentally CEO and striving servant leader from 2013."
+      github = "http://www.github.com/stickgrinder"
+      twitter = "http://www.twitter.com/stickgrinder"
+
+    [Params.Authors.Paolo]
+      name = "Paolo Mainardi"
+      role = "CTO"
+      picture = "http://www.sparkfabrik.com/images/team/paolo.jpg"
+      bio = "Hacker, open-source enthusiast, reddit addicted and now proud founder of Sparkfabrik."
+      github = "http://www.github.com/paolomainardi"
+      twitter = "http://www.twitter.com/paolomainardi"
+
+    [Params.Authors.Pinolo]
+      name = "Marcello Testi"
+      role = "Lead Developer"
+      picture = "http://www.sparkfabrik.com/images/team/pinolo.jpg"
+      bio = "Long-time open-source contributor, avid music listener. In Sparkfabrik since day-1."
+      github = "http://www.github.com/pinolo"
+      twitter = "http://www.twitter.com/pinolo"
+
+
 [Author]
   name = "Sparkfabrik"
   email = "info@sparkfabrik.com"

--- a/src/content/post/20160405_bbh.md
+++ b/src/content/post/20160405_bbh.md
@@ -5,14 +5,12 @@ tags        = ['drush8', 'hugo', 'user experience', 'design']
 topics      = ['Brown bag happy hour']
 description = "First spring BBH"
 slug        = 'brown-bag-happy-hour'
-author      = "Marcello Gorla"
+author      = "Marcello"
 +++
 [SparkFabrik]: http://www.sparkfabrik.com/  "SparkFabrik"
 [Fast Co Design]: http://www.fastcodesign.com/3058517/frog-will-have-no-more-chief-creative-officers "Fast Co Design"
 
 In the first BBH of spring 2016 Marcello Testi discussed about Drush Make related issues within Drush8, and Paolo Mainardi introduced the Hugo static site generator to the team in order to kickstart the [SparkFabrik] Tech Blog. We also talked a little about design thanks to our weekly news digest.
-
-By <a href="/page/team#marcello_gorla">Marcello Gorla</a>
 
 <!--more-->
 

--- a/src/content/post/hello-world.md
+++ b/src/content/post/hello-world.md
@@ -3,6 +3,7 @@ date = "2016-03-23T16:31:55Z"
 draft = false
 title = "Hello world"
 description = "Subtitle of the post (also used as meta description)"
+author = "Paolo"
 +++
 
 Hello world, posts are coming.

--- a/src/themes/spark/layouts/partials/author.html
+++ b/src/themes/spark/layouts/partials/author.html
@@ -1,0 +1,13 @@
+{{ $author := index .Site.Params.Authors .Params.author }}
+<div class="author-block">
+  <div class="col-lg-8 col-lg-offset-2 col-md-8 col-md-offset-2 ">
+    <p class="about">About the author</p>
+  </div>
+  <div class="col-lg-1 col-lg-offset-2 col-md-1 col-md-offset-1">
+    <img src="{{ $author.picture }}" alt="{{ $author.name }}" class="img-rounded pull-left avatar">
+  </div>
+  <div class="col-lg-7 col-md-7">
+     <h4> <a href="/page/team#{{ .Params.author }}" >{{ $author.name }} </a> <small>[ {{ $author.role }} ]</small></h4>
+     <p class="bio">{{ $author.bio }}</p>
+  </div>
+</div>

--- a/src/themes/spark/layouts/partials/post.html
+++ b/src/themes/spark/layouts/partials/post.html
@@ -16,7 +16,10 @@
   <div class="row">
     <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
 	  {{ .Content }}
-	</div>
+    </div>
+  </div>
+  <div class="row">
+    {{ partial "author.html" . }}
   </div>
 </article>
 

--- a/src/themes/spark/static/css/main.css
+++ b/src/themes/spark/static/css/main.css
@@ -457,3 +457,70 @@ table tr td :last-child {
   font-size: 36px;
   color: #404040;
 }
+
+.spark-icon
+    {
+      font-family: "fontello";
+      font-style: normal;
+      font-weight: normal;
+      speak: none;
+
+      /*display: inline-block;
+      text-decoration: inherit;
+      width: 1em;
+      margin-right: .2em;
+      text-align: center;*/
+      /* opacity: .8; */
+
+      /* For safety - reset parent styles, that can break glyph codes*/
+      font-variant: normal;
+      text-transform: none;
+
+      /* fix buttons height, for twitter bootstrap */
+/*      line-height: 1em;
+*/
+      /* Animation center compensation - margins should be symmetric */
+      /* remove if not needed */
+      /*margin-left: .2em;*/
+
+      /* You can be more comfortable with increased icons size */
+      /* font-size: 120%; */
+
+      /* Font smoothing. That was taken from TWBS */
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+
+      /* Uncomment for 3D effect */
+      /* text-shadow: 1px 1px 1px rgba(127, 127, 127, 0.3); */
+      font-size: 35px;
+      margin-right: -10px;
+      color: #E60000;
+      float:left;
+      margin-left:-17px;
+    }
+
+
+/* --- Author block below posts --- */
+
+div.author-block {
+      margin-top: 30px;
+}
+
+div.author-block p.about {
+      font-style: italic;
+      margin: 10px 0;
+      font-size: 1.2em;
+      border-top: 1px solid #ddd;
+      color: #808080;
+}
+div.author-block h4 {
+      margin: 0 0 10px 0;
+}
+div.author-block h4 small {
+      position: relative;
+      top: -0.1em;
+}
+div.author-block p.bio {
+      margin: 0;
+      font-size: 0.9em;
+}


### PR DESCRIPTION
This adds support for multiple authors. Check `src/config.toml` to see added authors information.

Mind that the team page is still _not_ using these information to render. I'll add that to the soup, in the meantime we have more info on the single page.
